### PR TITLE
Bump syft to 0.38.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, rockylinux-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 ```yaml
 syft_app: syft
 syft_desired_state: present
-syft_version: 0.36.0
+syft_version: 0.38.0
 syft_os: linux
 syft_arch: amd64
 
@@ -34,7 +34,7 @@ Variable           | Description
 ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------
 syft_app           | Defines the app to install i.e. **syft**
 syft_desired_state | Defined to dynamically chose whether to install (i.e. either `present` or `latest`) or uninstall (i.e. `absent`) the package. Defaults to `present`.
-syft_version       | Defined to dynamically fetch the desired version to install. Defaults to: **0.36.0**
+syft_version       | Defined to dynamically fetch the desired version to install. Defaults to: **0.38.0**
 syft_os            | Defines os type. Used for obtaining the correct type of binaries based on OS type. Defaults to: **linux**
 syft_arch          | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
 syft_debian_url    | Defines URL to download the 'deb' package from for Debian/Ubuntu family systems.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 syft_app: syft
 syft_desired_state: present
-syft_version: 0.36.0
+syft_version: 0.38.0
 syft_os: linux
 syft_arch: amd64
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,5 @@
   hosts: all
   roles:
     - role: darkwizard242.syft
+  vars:
+    ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
- Bump `syft` to **0.38.0**
- Utilize Rocky Linux 8 for EL 8 OS versions