### PR TITLE
bump syft to 0.46.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,9 +47,9 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 6
+      max-parallel: 10
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, rockylinux-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, rockylinux-8, centos-7, debian-bullseye, debian-buster, debian-stretch]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 ```yaml
 syft_app: syft
 syft_desired_state: present
-syft_version: 0.46.0
+syft_version: 0.46.1
 syft_os: linux
 syft_arch: amd64
 
@@ -34,7 +34,7 @@ Variable           | Description
 ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------
 syft_app           | Defines the app to install i.e. **syft**
 syft_desired_state | Defined to dynamically chose whether to install (i.e. either `present` or `latest`) or uninstall (i.e. `absent`) the package. Defaults to `present`.
-syft_version       | Defined to dynamically fetch the desired version to install. Defaults to: **0.46.0**
+syft_version       | Defined to dynamically fetch the desired version to install. Defaults to: **0.46.1**
 syft_os            | Defines os type. Used for obtaining the correct type of binaries based on OS type. Defaults to: **linux**
 syft_arch          | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
 syft_debian_url    | Defines URL to download the 'deb' package from for Debian/Ubuntu family systems.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 syft_app: syft
 syft_desired_state: present
-syft_version: 0.46.0
+syft_version: 0.46.1
 syft_os: linux
 syft_arch: amd64
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,8 +11,8 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - jammy
-        - bionic
         - focal
+        - bionic
     - name: Debian
       versions:
         - bullseye
@@ -20,8 +20,8 @@ galaxy_info:
         - stretch
     - name: EL
       versions:
-        - 7
         - 8
+        - 7
 
   galaxy_tags:
     - syft

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,12 +10,14 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - jammy
         - bionic
         - focal
     - name: Debian
       versions:
-        - stretch
+        - bullseye
         - buster
+        - stretch
     - name: EL
       versions:
         - 7


### PR DESCRIPTION
- Add support for Ubuntu 22.04 & Debian Bullseye